### PR TITLE
🎨 Palette: Improve accessibility of "Learn more" links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,6 @@
 ## 2026-03-25 - Avoid Aria-label Mismatch for Inline Links
 **Learning:** Found a pattern where `aria-label`s were used on inline links to provide completely different, more descriptive text than what was visible (e.g., `[Download](url){ aria-label="Download Windows Installer" }`). This is a severe violation of WCAG 2.5.3 (Label in Name) because screen reader users searching for "Download" may not find it, and speech-recognition users saying "Click Download" might fail.
 **Action:** Never use `aria-label` to replace poor link text. Instead, always update the visible text to be descriptive and self-sufficient (e.g., `[Download Windows Installer](url)`).
+## 2025-03-29 - [Descriptive Link Text]
+**Learning:** Using `aria-label` to fix generic link text (like "Learn more") is an anti-pattern when we can just make the visible text itself descriptive. Descriptive visible text helps all users, not just screen reader users, and avoids WCAG 2.5.3 (Label in Name) violations where the label might not contain the visible text perfectly.
+**Action:** Always prefer updating the visible text of a link to be descriptive rather than adding an `aria-label` to generic text.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more](https://docs.eddy3d.com/outdoor/){ aria-label="Learn more about Eddy3D Outdoor module" }
+    [:octicons-arrow-right-24: Learn more about Eddy3D Outdoor](https://docs.eddy3d.com/outdoor/)
 
 - __Eddy3D Outdoor+__
 
@@ -22,7 +22,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more](https://docs.eddy3d.com/outdoorplus/){ aria-label="Learn more about Eddy3D Outdoor+ module" }
+    [:octicons-arrow-right-24: Learn more about Eddy3D Outdoor+](https://docs.eddy3d.com/outdoorplus/)
 
 - __Eddy3D Indoor__
 
@@ -32,7 +32,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more](https://docs.eddy3d.com/indoor/){ aria-label="Learn more about Eddy3D Indoor module" }
+    [:octicons-arrow-right-24: Learn more about Eddy3D Indoor](https://docs.eddy3d.com/indoor/)
 
 </div>
 


### PR DESCRIPTION
💡 What: Changed the generic "Learn more" links on the homepage to have descriptive visible text (e.g., "Learn more about Eddy3D Outdoor"). Removed the redundant `aria-label`s.
🎯 Why: Using descriptive visible link text benefits all users (not just screen reader users) by clearly indicating the link's destination without requiring surrounding context. It avoids the anti-pattern of using `aria-label` to fix generic text like "Learn more".
♿ Accessibility: Improved link context for all users, reduced reliance on `aria-label` which screen readers can sometimes struggle with, and ensured compliance with WCAG principles by making the visible text itself meaningful.

---
*PR created automatically by Jules for task [1486435280352468910](https://jules.google.com/task/1486435280352468910) started by @kastnerp*