### PR TITLE
🎨 Palette: Accessible external LinkedIn link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,6 @@
 ## 2026-03-25 - Avoid "these instructions" anti-pattern
 **Learning:** Using link text like "these instructions for..." creates a poor experience for screen reader users and those navigating out of context. The link text should be fully self-descriptive without needing surrounding context.
 **Action:** Always prefer updating the visible text of the link to be descriptive and human-readable (e.g., change `see [these instructions for matching MPI DLL files](...)` to `see the [CFD Online instructions for matching MPI DLL files](...)`).
+## 2026-04-02 - Accessible External Links
+**Learning:** When changing links to open in a new tab () to keep users in the application context, we MUST communicate this context shift to screen reader users by appending '(opens in a new tab)' to the `aria-label`. Additionally, `rel="noopener noreferrer"` is crucial for security.
+**Action:** For all future external links that open in a new tab, include `target="_blank"`, `rel="noopener noreferrer"`, and an `aria-label` warning for screen readers.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -99,7 +99,7 @@
 <!-- Announcement bar -->
 {% block announce %}
   For updates follow <strong>Eddy3D</strong> on
-  <a rel="me" href="https://www.linkedin.com/company/eddy3d-com" aria-label="Follow Eddy3D on LinkedIn">
+  <a rel="me noopener noreferrer" target="_blank" href="https://www.linkedin.com/company/eddy3d-com" aria-label="Follow Eddy3D on LinkedIn (opens in a new tab)">
     <span class="twemoji linkedin">
       {% include ".icons/fontawesome/brands/linkedin.svg" %}
     </span>


### PR DESCRIPTION
💡 **What**: The external LinkedIn link in the announcement bar now opens in a new tab with proper security (`rel="noopener noreferrer"`) and an updated `aria-label` to warn screen readers (`(opens in a new tab)`).
🎯 **Why**: Previously, clicking the LinkedIn link took users away from the documentation site, breaking their flow. Opening it in a new tab improves UX, but without a warning, it can disorient screen reader users. This change fixes both the flow interruption and the accessibility oversight.
📸 **Before/After**: The visual change is subtle (opens in a new tab), but the screen reader experience is significantly improved.
♿ **Accessibility**: Warns screen reader users of an impending context shift (opening a new tab/window).

---
*PR created automatically by Jules for task [15064381489988362534](https://jules.google.com/task/15064381489988362534) started by @kastnerp*