### PR TITLE
🎨 Palette: Improve link accessibility (WCAG 2.5.3)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,10 +65,10 @@ The Grasshopper plugin currently contains three modules, please see below.
 | Plugin | Platform | Link |
 |----------|----------|----------------|
 | **Eddy3D** (Outdoor / Indoor) | Windows | [Download Eddy3D Installer for Windows](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Download Eddy3D Installer for Windows (opens in a new tab)" } |
-| **Eddy3D-OutdoorPlus** (Outdoor+) | Windows / Mac | [Install `UMCF` via Rhino Package Manager (`yak`)](https://rhinopackages.github.io/?search=Umcf&sort=2){ target="_blank" rel="noopener noreferrer" aria-label="Install UMCF via Rhino Package Manager (opens in a new tab)" } |
+| **Eddy3D-OutdoorPlus** (Outdoor+) | Windows / Mac | [Install `UMCF` via Rhino Package Manager (`yak`)](https://rhinopackages.github.io/?search=Umcf&sort=2){ target="_blank" rel="noopener noreferrer" aria-label="Install UMCF via Rhino Package Manager (yak) (opens in a new tab)" } |
 
 !!! tip "Previous Versions"
-    Required Rhino 8.27 build details are listed at [**View required Rhino 8.27 build details (8.27.26019.16022, en-us)**](https://rhinoversions.github.io/?version=8.27.26019.16022&locale=en-us){ target="_blank" rel="noopener noreferrer" aria-label="View required Rhino 8.27 build details (opens in a new tab)" }.
+    Required Rhino 8.27 build details are listed at [**View required Rhino 8.27 build details (8.27.26019.16022, en-us)**](https://rhinoversions.github.io/?version=8.27.26019.16022&locale=en-us){ target="_blank" rel="noopener noreferrer" aria-label="View required Rhino 8.27 build details (8.27.26019.16022, en-us) (opens in a new tab)" }.
 
 !!! note "Plugin Naming"
     The **Outdoor+** module is currently distributed under the package name **`UMCF`** via the Rhino Package Manager (`yak`). Ensure you enable **"Include pre-releases"** in the Package Manager.


### PR DESCRIPTION
🎨 Palette: Improve link accessibility (WCAG 2.5.3)

💡 What: Updated `aria-label` attributes on external links in `docs/index.md` to perfectly match their visible text.
🎯 Why: Ensures compliance with WCAG 2.5.3 (Label in Name), preventing a disconnect for screen reader and voice dictation users when the visible text differs from the accessible name.
♿ Accessibility:
- The `aria-label` for the UMCF package manager link now includes the `(yak)` text.
- The `aria-label` for the Rhino build requirements link now includes the version details.
- Both maintain the `(opens in a new tab)` suffix for context.

---
*PR created automatically by Jules for task [3109949753889365728](https://jules.google.com/task/3109949753889365728) started by @kastnerp*