### PR TITLE
🎨 Palette: Improve index documentation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,6 @@
 ## 2026-04-02 - Accessible External Links
 **Learning:** When changing links to open in a new tab () to keep users in the application context, we MUST communicate this context shift to screen reader users by appending '(opens in a new tab)' to the `aria-label`. Additionally, `rel="noopener noreferrer"` is crucial for security.
 **Action:** For all future external links that open in a new tab, include `target="_blank"`, `rel="noopener noreferrer"`, and an `aria-label` warning for screen readers.
+## 2026-03-27 - Replace generic link text with specific descriptive visible text
+**Learning:** When changing links for accessibility, instead of using 'Learn more' and fixing it via an `aria-label`, updating the visible text itself to be fully descriptive (e.g., 'View Eddy3D Outdoor Documentation') provides a better experience for all users and guarantees WCAG 2.5.3 compliance.
+**Action:** Always prefer to update visible text to be self-descriptive instead of relying on `aria-label` attributes to patch generic link text.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more about Eddy3D Outdoor](https://docs.eddy3d.com/outdoor/)
+    [:octicons-arrow-right-24: View Eddy3D Outdoor Documentation](outdoor/index.md)
 
 - __Eddy3D Outdoor+__
 
@@ -22,7 +22,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more about Eddy3D Outdoor+](https://docs.eddy3d.com/outdoorplus/)
+    [:octicons-arrow-right-24: View Eddy3D Outdoor+ Documentation](outdoorplus/index.md)
 
 - __Eddy3D Indoor__
 
@@ -32,7 +32,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 
     ---
 
-    [:octicons-arrow-right-24: Learn more about Eddy3D Indoor](https://docs.eddy3d.com/indoor/)
+    [:octicons-arrow-right-24: View Eddy3D Indoor Documentation](indoor/index.md)
 
 </div>
 


### PR DESCRIPTION
🎨 Palette: Improve index documentation links

💡 What: Changed the "Learn more" absolute links in the index page to descriptive relative links.
🎯 Why: Makes the links more self-descriptive ("View Eddy3D Outdoor Documentation") avoiding the need for `aria-label` hacks. Also changes absolute production URLs to relative markdown paths, keeping users within their current context (local preview or GitHub repo view).
♿ Accessibility: Eliminates generic "Learn more" text and ensures the visible text is fully descriptive, compliant with WCAG 2.5.3 without relying on `aria-label`.

---
*PR created automatically by Jules for task [5879738596855988794](https://jules.google.com/task/5879738596855988794) started by @kastnerp*