### PR TITLE
🎨 Palette: Improve link UX by removing repetitive text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ The Grasshopper plugin currently contains three modules, please see below.
 | **Eddy3D-OutdoorPlus** (Outdoor+) | Windows / Mac | [Install `UMCF` via Rhino Package Manager (`yak`)](https://rhinopackages.github.io/?search=Umcf&sort=2){ target="_blank" rel="noopener noreferrer" aria-label="Install UMCF via Rhino Package Manager (yak) (opens in a new tab)" } |
 
 !!! tip "Previous Versions"
-    Required Rhino 8.27 build details are listed at [**View required Rhino 8.27 build details (8.27.26019.16022, en-us)**](https://rhinoversions.github.io/?version=8.27.26019.16022&locale=en-us){ target="_blank" rel="noopener noreferrer" aria-label="View required Rhino 8.27 build details (8.27.26019.16022, en-us) (opens in a new tab)" }.
+    View the [**required Rhino 8.27 build details (8.27.26019.16022, en-us)**](https://rhinoversions.github.io/?version=8.27.26019.16022&locale=en-us){ target="_blank" rel="noopener noreferrer" aria-label="required Rhino 8.27 build details (8.27.26019.16022, en-us) (opens in a new tab)" }.
 
 !!! note "Plugin Naming"
     The **Outdoor+** module is currently distributed under the package name **`UMCF`** via the Rhino Package Manager (`yak`). Ensure you enable **"Include pre-releases"** in the Package Manager.


### PR DESCRIPTION
💡 What: Replaced repetitive link copy in `docs/index.md` ("Required Rhino 8.27 build details are listed at View required Rhino 8.27 build details...") with a flowing sentence ("View the required Rhino 8.27 build details...").
🎯 Why: Reduces cognitive load and fixes a highly redundant sentence. It makes reading smoother for both sighted and screen reader users.
♿ Accessibility: The `aria-label` continues to effectively describe the external link and warn users that it opens in a new tab, but now the preceding text isn't a duplicate.

---
*PR created automatically by Jules for task [15961262058932208188](https://jules.google.com/task/15961262058932208188) started by @kastnerp*