### PR TITLE
🎨 Palette: Lazy load heavy GIFs to improve page performance

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -48,3 +48,6 @@
 ## 2026-03-27 - Replace generic link text with specific descriptive visible text
 **Learning:** When changing links for accessibility, instead of using 'Learn more' and fixing it via an `aria-label`, updating the visible text itself to be fully descriptive (e.g., 'View Eddy3D Outdoor Documentation') provides a better experience for all users and guarantees WCAG 2.5.3 compliance.
 **Action:** Always prefer to update visible text to be self-descriptive instead of relying on `aria-label` attributes to patch generic link text.
+## 2026-04-12 - Lazy Loading Large Images
+**Learning:** Large GIFs in documentation can cause significant page jank and slow initial load times, negatively impacting the reading experience.
+**Action:** Use the MkDocs `attr_list` extension to append `{ loading=lazy }` to heavy media elements like animated GIFs.

--- a/docs/outdoorplus/index.md
+++ b/docs/outdoorplus/index.md
@@ -3,7 +3,7 @@
 !!! warning "Alpha Version"
     This module is currently in alpha testing. Features, inputs, and outputs are subject to change without notice.
 
-![urbanMicroclimateFoam simulation preview](./images/outdoorplus/umcf.gif)
+![urbanMicroclimateFoam simulation preview](./images/outdoorplus/umcf.gif){ loading=lazy }
 ### A Grasshopper plugin for microclimate simulations
 
 ___
@@ -23,9 +23,9 @@ ___
 🌳 **VEG** - Solves heat balance for urban trees
 - Handles green surfaces
 
-![Analysis & Visualization showing wind patterns](images/outdoorplus/image38.gif)
+![Analysis & Visualization showing wind patterns](images/outdoorplus/image38.gif){ loading=lazy }
 
-![Analysis & Visualization showing temperature and humidity distributions](images/outdoorplus/image39.gif)
+![Analysis & Visualization showing temperature and humidity distributions](images/outdoorplus/image39.gif){ loading=lazy }
 
 ### Acknowledgments
 


### PR DESCRIPTION
Added lazy loading attributes to large GIF media in the Outdoor+ documentation.

The `docs/outdoorplus/index.md` file contained three animated GIFs totaling ~8MB (`umcf.gif`, `image38.gif`, `image39.gif`). When rendered, they caused a significant performance hit on initial page load.

Leveraging the existing MkDocs `attr_list` plugin, `{ loading=lazy }` was appended to the Markdown image tags. This simple UX enhancement defers loading the images until they are near the viewport, greatly improving the perceived load time and reducing page jank without any complex configuration changes.

---
*PR created automatically by Jules for task [10057481727886109039](https://jules.google.com/task/10057481727886109039) started by @kastnerp*