### PR TITLE
🎨 Palette: Add lazy loading to GIFs in Outdoor+ index

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -48,3 +48,6 @@
 ## 2026-03-27 - Replace generic link text with specific descriptive visible text
 **Learning:** When changing links for accessibility, instead of using 'Learn more' and fixing it via an `aria-label`, updating the visible text itself to be fully descriptive (e.g., 'View Eddy3D Outdoor Documentation') provides a better experience for all users and guarantees WCAG 2.5.3 compliance.
 **Action:** Always prefer to update visible text to be self-descriptive instead of relying on `aria-label` attributes to patch generic link text.
+## 2025-04-13 - Lazy Loading Large Images
+**Learning:** Found that large animated GIFs in the documentation can cause page load jank and impact performance for users on slower connections.
+**Action:** Append `{ loading=lazy }` to large images and GIFs using the MkDocs `attr_list` extension to ensure they are lazy-loaded, improving initial page load times and overall performance.

--- a/docs/outdoorplus/index.md
+++ b/docs/outdoorplus/index.md
@@ -3,7 +3,7 @@
 !!! warning "Alpha Version"
     This module is currently in alpha testing. Features, inputs, and outputs are subject to change without notice.
 
-![urbanMicroclimateFoam simulation preview](./images/outdoorplus/umcf.gif)
+![urbanMicroclimateFoam simulation preview](./images/outdoorplus/umcf.gif){ loading=lazy }
 ### A Grasshopper plugin for microclimate simulations
 
 ___
@@ -23,9 +23,9 @@ ___
 🌳 **VEG** - Solves heat balance for urban trees
 - Handles green surfaces
 
-![Analysis & Visualization showing wind patterns](images/outdoorplus/image38.gif)
+![Analysis & Visualization showing wind patterns](images/outdoorplus/image38.gif){ loading=lazy }
 
-![Analysis & Visualization showing temperature and humidity distributions](images/outdoorplus/image39.gif)
+![Analysis & Visualization showing temperature and humidity distributions](images/outdoorplus/image39.gif){ loading=lazy }
 
 ### Acknowledgments
 


### PR DESCRIPTION
💡 What: Added `{ loading=lazy }` to three large animated GIFs in the Outdoor+ index page.
🎯 Why: Animated GIFs can be large and cause page load jank. Deferring their loading until they are near the viewport improves initial page load times and overall performance.
📸 Before/After: N/A (Performance/loading optimization)
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [15687440857900992145](https://jules.google.com/task/15687440857900992145) started by @kastnerp*