### PR TITLE
🎨 Palette: Fix aria-label mismatches in docs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -58,3 +58,7 @@
 ## 2026-04-12 - Lazy Loading Large Images
 **Learning:** Large GIFs in documentation can cause significant page jank and slow initial load times, negatively impacting the reading experience.
 **Action:** Use the MkDocs `attr_list` extension to append `{ loading=lazy }` to heavy media elements like animated GIFs.
+
+## 2026-05-28 - Visible action verbs in links
+**Learning:** Found a pattern where links were placed within sentences, but the action verb (e.g., 'Install' or 'Download') was kept outside the link text, while an `aria-label` was added to the link to provide the missing verb to screen readers. This creates a mismatch for speech dictation users and slightly degrades the experience for sighted users navigating via links.
+**Action:** Include the action verb within the visible link text to make it fully self-descriptive and match the `aria-label` perfectly (WCAG 2.4.4 and 2.5.3).

--- a/docs/outdoor/index.md
+++ b/docs/outdoor/index.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ### Plugin
-- **Windows:** Install [Eddy3D for Windows](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Install Eddy3D for Windows (opens in a new tab)" }
+- **Windows:** [Install Eddy3D for Windows](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Install Eddy3D for Windows (opens in a new tab)" }
 - **Mac:** Install **`Eddy3D-OutdoorPlus`** via Rhino Package Manager (`yak`)
 
 ### Simulation Engines (Windows / Mac)
@@ -12,7 +12,7 @@ Choose a simulation engine (one of the following):
 - **BlueCFD 2020 (Windows Only):** [Download BlueCFD 2020 installer](https://github.com/blueCFD/Core/releases/download/blueCFD-Core-2020-1/blueCFD-Core-2020-1-win64-setup.exe){ target="_blank" rel="noopener noreferrer" aria-label="Download BlueCFD 2020 installer (opens in a new tab)" } (Requires `urbanMicroclimateFoam` to be installed manually)
 - **WSL (Windows Only):** [WSL Installation guide for Windows](https://learn.microsoft.com/en-us/windows/wsl/install){ target="_blank" rel="noopener noreferrer" aria-label="WSL Installation guide for Windows (opens in a new tab)" } (Requires `urbanMicroclimateFoam` to be installed manually)
 
-If you would like to use the *experimental* MRT component, please install [Radiance 5.3](https://github.com/LBNL-ETA/Radiance/releases/tag/012cb178){ target="_blank" rel="noopener noreferrer" aria-label="Install Radiance 5.3 (opens in a new tab)" } in the default folder: `C:\Program Files\Radiance` (Windows) or via your package manager (Mac).
+If you would like to use the *experimental* MRT component, please [install Radiance 5.3](https://github.com/LBNL-ETA/Radiance/releases/tag/012cb178){ target="_blank" rel="noopener noreferrer" aria-label="Install Radiance 5.3 (opens in a new tab)" } in the default folder: `C:\Program Files\Radiance` (Windows) or via your package manager (Mac).
 
 ### Templates
 


### PR DESCRIPTION
💡 What: Included action verbs "Install" directly within the visible link text in `docs/outdoor/index.md`.
🎯 Why: To fix WCAG 2.5.3 (Label in Name) violations where the visible text ("Eddy3D for Windows" and "Radiance 5.3") did not fully match their more descriptive aria-labels ("Install Eddy3D for Windows..." and "Install Radiance 5.3..."). This makes the links fully self-descriptive for all users.
♿ Accessibility: Improved link context for screen readers and fixed speech-to-text mismatches.

---
*PR created automatically by Jules for task [15953870794245929445](https://jules.google.com/task/15953870794245929445) started by @kastnerp*