### PR TITLE
Docs: reconcile with unified Eddy3D 1.0.0.827 release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# UMCF Component list
+# Eddy3D — Component Reference
 
 ## Air
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,19 +56,19 @@ The Grasshopper plugin currently contains three modules, please see below.
 
 | Module   | Overview                                                     | Core engine            | Package | Rhino (ver) | OS support  | OpenFOAM (ver) | Radiance (ver) |
 |----------|--------------------------------------------------------------|------------------------|-----------------------|-------------|----------------|----------------|----------------|
-| Outdoor  | Decoupled wind + mean radiant temp                           | OpenFOAM; Radiance     | **Eddy3D**            | 8.27        | Windows (Mac via manual install)     | 8              |  Radiance 5.3  |
-| Outdoor+ | Fully coupled (wind, radiation, heat, moisture) | OpenFOAM   | **Eddy3D-OutdoorPlus** | 8.21                  | Windows/Mac | 8              | —              |
-| Indoor   | Airflow, moisture, passive scalars (indoor)                  | OpenFOAM               | **Eddy3D**            | 8.27        | Windows (Mac via manual install)     | 8              | -              |
+| Outdoor  | Decoupled wind + mean radiant temp                           | OpenFOAM; Radiance     | **Eddy3D**            | 8.27        | Windows / Mac     | 12              |  Radiance 5.3  |
+| Outdoor+ | Fully coupled (wind, radiation, heat, moisture) | OpenFOAM   | **Eddy3D** | 8.27                  | Windows / Mac | 12              | —              |
+| Indoor   | Airflow, moisture, passive scalars (indoor)                  | OpenFOAM               | **Eddy3D**            | 8.27        | Windows / Mac     | 12              | -              |
 
 ## Downloads
 
 | Plugin | Platform | Link |
 |----------|----------|----------------|
-| **Eddy3D** (Outdoor / Indoor) | Windows | [Download Eddy3D Installer for Windows](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Download Eddy3D Installer for Windows (opens in a new tab)" } |
-| **Eddy3D-OutdoorPlus** (Outdoor+) | Windows / Mac | [Install `UMCF` via Rhino Package Manager (`yak`)](https://rhinopackages.github.io/?search=Umcf&sort=2){ target="_blank" rel="noopener noreferrer" aria-label="Install UMCF via Rhino Package Manager (yak) (opens in a new tab)" } |
+| **Eddy3D** (Outdoor, Outdoor+, Indoor, MRT, FluidX3D) | Windows / Mac | [Install via the Rhino Package Manager &mdash; search **`Eddy3D`**](https://rhinopackages.github.io/?search=Eddy3D&sort=2){ target="_blank" rel="noopener noreferrer" aria-label="Install Eddy3D via the Rhino Package Manager (opens in a new tab)" } |
+| **Eddy3D** (Windows installer) | Windows | [Download standalone installer](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Download Eddy3D installer for Windows (opens in a new tab)" } |
 
 !!! tip "Previous Versions"
     View the [**required Rhino 8.27 build details (8.27.26019.16022, en-us)**](https://rhinoversions.github.io/?version=8.27.26019.16022&locale=en-us){ target="_blank" rel="noopener noreferrer" aria-label="required Rhino 8.27 build details (8.27.26019.16022, en-us) (opens in a new tab)" }.
 
-!!! note "Plugin Naming"
-    The **Outdoor+** module is currently distributed under the package name **`UMCF`** via the Rhino Package Manager (`yak`). Ensure you enable **"Include pre-releases"** in the Package Manager.
+!!! note "One package"
+    All modules &mdash; Outdoor, Outdoor+, Indoor, MRT, and FluidX3D &mdash; now ship in the single **`Eddy3D`** package on the Rhino Package Manager (`yak`). The former separate **`UMCF`** package (Outdoor+) has been retired.

--- a/docs/indoor/README.md
+++ b/docs/indoor/README.md
@@ -1,4 +1,4 @@
-# UMCF Component list
+# Eddy3D — Indoor Component list
 ## 9 Indoor
 #### Main Components
 * [CO2 Emitter](components/CO2_Emitter.md)

--- a/docs/indoor/components/CO2_Emitter.md
+++ b/docs/indoor/components/CO2_Emitter.md
@@ -7,7 +7,7 @@ CO2 Source
  Simulates carbon dioxide generation, typically from occupants. Use this to assess ventilation effectiveness and air quality.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Heat_Source.md
+++ b/docs/indoor/components/Heat_Source.md
@@ -7,7 +7,7 @@ Heat Source
  Models a heat-generating object within the indoor space, such as equipment, electronics, or a cluster of people. Can be defined by total power (W) or power density (W/m³).
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Indoor_Inlet.md
+++ b/docs/indoor/components/Indoor_Inlet.md
@@ -7,7 +7,7 @@ Ventilation Inlet
  Defines where air enters the room, such as diffusers, windows, or doors.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Indoor_Outlet.md
+++ b/docs/indoor/components/Indoor_Outlet.md
@@ -7,7 +7,7 @@ Ventilation Outlet
  Defines where air exhausts from the room, such as return grilles or open windows.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Indoor_Simulation.md
+++ b/docs/indoor/components/Indoor_Simulation.md
@@ -10,7 +10,7 @@ Indoor Airflow Solver
  Requires connected walls, inlets, outlets, and optional heat sources.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Indoor_Wall.md
+++ b/docs/indoor/components/Indoor_Wall.md
@@ -7,7 +7,7 @@ Indoor Wall/Boundary
  Defines a solid boundary for indoor simulations, such as walls, floors, or ceilings. Allows specification of surface temperature for thermal analysis.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Momentum_Sink.md
+++ b/docs/indoor/components/Momentum_Sink.md
@@ -7,7 +7,7 @@ Flow Resistance Zone
  Creates a volume that resists airflow, simulating obstacles like furniture, equipment, or dense vegetation in indoor or outdoor models. Reduces air velocity passing through it.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Momentum_Source.md
+++ b/docs/indoor/components/Momentum_Source.md
@@ -7,7 +7,7 @@ Fan / Jet Source
  Creates a volume that actively pushes air in a specific direction. Use this to model fans, blowers, HVAC supply jets, or other active airflow devices.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/indoor/components/Viral_Emitter.md
+++ b/docs/indoor/components/Viral_Emitter.md
@@ -7,7 +7,7 @@ Pathogen Source
  Simulates the release of airborne pathogens (e.g., viruses) from a specific location to analyze infection risk and dispersion patterns.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/outdoor/README.md
+++ b/docs/outdoor/README.md
@@ -1,4 +1,4 @@
-# UMCF Component list
+# Eddy3D — Outdoor Component list
 ## 0 Load Templates
 #### Main Components
 * [Templates](components/Templates.md)

--- a/docs/outdoor/components/ABL_Flow.md
+++ b/docs/outdoor/components/ABL_Flow.md
@@ -7,7 +7,7 @@ Atmospheric Boundary Layer (ABL) Inlet
  Sets up a logarithmic wind profile based on aerodynamic roughness length (z0). Essential for accurate urban wind flow simulation, representing the friction of the upwind terrain.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dir 

--- a/docs/outdoor/components/Analysis_Period.md
+++ b/docs/outdoor/components/Analysis_Period.md
@@ -7,7 +7,7 @@ Analysis Period
  Defines a specific time period for analysis (e.g., Summer from 9am-5pm). Outputs a list of hours (HOY) to filter simulation results for seasonal or daily studies.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### F 

--- a/docs/outdoor/components/Analysis_System.md
+++ b/docs/outdoor/components/Analysis_System.md
@@ -3,7 +3,7 @@
 ![Analysis System Component](../images/components/Analysis_System-crop.png)
 
 Analysis System
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### AB 

--- a/docs/outdoor/components/Box_Domain.md
+++ b/docs/outdoor/components/Box_Domain.md
@@ -7,7 +7,7 @@ Rectangular Simulation Domain
  Defines a box-shaped computational domain for the wind simulation. Best suited for single-direction wind analysis or wind tunnel comparisons.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Bldg 

--- a/docs/outdoor/components/Building_Surface.md
+++ b/docs/outdoor/components/Building_Surface.md
@@ -7,7 +7,7 @@ Building Material
  Assigns thermal and optical properties to building geometries. Affects how buildings reflect sunlight and emit heat.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/outdoor/components/Clean_Directories.md
+++ b/docs/outdoor/components/Clean_Directories.md
@@ -7,7 +7,7 @@ Project Cleaner
  Utility to remove generated simulation files and free up disk space. Use with caution as it deletes results.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Comfort.md
+++ b/docs/outdoor/components/Comfort.md
@@ -3,7 +3,7 @@
 ![Comfort Component](../images/components/Comfort-crop.png)
 
 Comfort System
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### MRT 

--- a/docs/outdoor/components/Cull_Ground_Mesh.md
+++ b/docs/outdoor/components/Cull_Ground_Mesh.md
@@ -8,7 +8,7 @@ Remove ground mesh faces that intersect buildings.
  Can be slow for large meshes - consider using QuadRemesh first.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Bldg 

--- a/docs/outdoor/components/Custom_Time_Filter.md
+++ b/docs/outdoor/components/Custom_Time_Filter.md
@@ -7,7 +7,7 @@ Filter analysis results by custom date/time range.
  Specify start and end DateTime objects for precise temporal filtering.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### From 

--- a/docs/outdoor/components/Cylindrical_Domain.md
+++ b/docs/outdoor/components/Cylindrical_Domain.md
@@ -7,7 +7,7 @@ Cylindrical Simulation Domain
  Defines a cylindrical computational domain. Recommended for multi-directional wind analysis as it allows for changing wind directions without re-meshing.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Bldg 

--- a/docs/outdoor/components/Date_to_HOY.md
+++ b/docs/outdoor/components/Date_to_HOY.md
@@ -7,7 +7,7 @@ Date to HOY
  Converts a specific Date and Time (Month, Day, Hour) into a single 'Hour of Year' integer (1-8760). Essential for querying specific timestamps in annual data.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### M 

--- a/docs/outdoor/components/Deconstruct_Data_Objects.md
+++ b/docs/outdoor/components/Deconstruct_Data_Objects.md
@@ -4,7 +4,7 @@
 
 Deconstruct data objects from pedestrian and outdoor thermal comfort post-processings into data trees. This component is slow if a large number of probes are requested.
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### D 

--- a/docs/outdoor/components/Flow_Rates.md
+++ b/docs/outdoor/components/Flow_Rates.md
@@ -3,7 +3,7 @@
 ![Flow Rates Component](../images/components/Flow_Rates-crop.png)
 
 Compute flow rates across a mesh while treating its vertices as velocity probes.
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### U 

--- a/docs/outdoor/components/Ground_Surface.md
+++ b/docs/outdoor/components/Ground_Surface.md
@@ -7,7 +7,7 @@ Ground Material
  Defines properties for ground surfaces like asphalt, concrete, or soil. Critical for analyzing the Urban Heat Island effect.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/outdoor/components/InterpolateUMag.md
+++ b/docs/outdoor/components/InterpolateUMag.md
@@ -4,7 +4,7 @@
 
 Interpolate UMag for GAN applications.
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### CP 

--- a/docs/outdoor/components/Load_MRT_Results.md
+++ b/docs/outdoor/components/Load_MRT_Results.md
@@ -7,7 +7,7 @@ MRT Results Loader
  Import calculated Mean Radiant Temperature (MRT) data for thermal comfort analysis.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Path 

--- a/docs/outdoor/components/Load_Wind_Results.md
+++ b/docs/outdoor/components/Load_Wind_Results.md
@@ -7,7 +7,7 @@ Wind Results Loader
  Import raw results from a completed wind simulation for further analysis and visualization.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Path 

--- a/docs/outdoor/components/MRT_Simulation.md
+++ b/docs/outdoor/components/MRT_Simulation.md
@@ -11,7 +11,7 @@ Mean Radiant Temperature (MRT) Solver
  - Longwave Surface Emissions
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dir 

--- a/docs/outdoor/components/Mean_Radiant_Temperature.md
+++ b/docs/outdoor/components/Mean_Radiant_Temperature.md
@@ -11,7 +11,7 @@ Mean Radiant Temperature.
  Please make sure Radiance is installed at: "C:\Program Files\Radiance".
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Mesh_Cell_Size.md
+++ b/docs/outdoor/components/Mesh_Cell_Size.md
@@ -8,7 +8,7 @@ Calculate required mesh refinement levels for a target cell size.
  refinement levels (halving) are needed to reach your target resolution.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dom 

--- a/docs/outdoor/components/Mesh_Sensor.md
+++ b/docs/outdoor/components/Mesh_Sensor.md
@@ -7,7 +7,7 @@ Mesh Sensor Grid
  Converts a mesh surface into a grid of sensors for MRT analysis. Each mesh face serves as a measurement point for radiation and thermal comfort.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Mesh 

--- a/docs/outdoor/components/Mesh_Settings.md
+++ b/docs/outdoor/components/Mesh_Settings.md
@@ -7,7 +7,7 @@ Meshing Parameters
  Controls the resolution and quality of the simulation grid (mesh). Adjust cell sizes to balance between simulation accuracy and computation time.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### BldMin 

--- a/docs/outdoor/components/Open_ParaView.md
+++ b/docs/outdoor/components/Open_ParaView.md
@@ -8,7 +8,7 @@ Launch ParaView for 3D CFD result visualization.
  pressure distributions, and streamlines. ParaView must be installed.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Outdoor_Thermal_Comfort.md
+++ b/docs/outdoor/components/Outdoor_Thermal_Comfort.md
@@ -3,7 +3,7 @@
 ![Outdoor Thermal Comfort Component](../images/components/Outdoor_Thermal_Comfort-crop.png)
 
 Outdoor Thermal Comfort. This components computes the UTCI from the outdoor comfort objects passed. For the wind velocities, a scale-up to 10 m height above ground is applied.
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Pedestrian_Wind_Comfort.md
+++ b/docs/outdoor/components/Pedestrian_Wind_Comfort.md
@@ -60,7 +60,7 @@ Pedestrian Wind Comfort Analysis
  3 - C   > 15 m/s    > 0.3 %     Dangerous
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### WFS 

--- a/docs/outdoor/components/Plot_Residuals.md
+++ b/docs/outdoor/components/Plot_Residuals.md
@@ -7,7 +7,7 @@ Convergence Monitor
  Visualizes the definition of simulation convergence (residuals) in real-time. Helps verify if the simulation has reached a stable solution.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Point_Probe_Inspector.md
+++ b/docs/outdoor/components/Point_Probe_Inspector.md
@@ -7,7 +7,7 @@ Point Probe Inspector
  Visualizes simulation data at specific sensor points. Displays metrics like Wind Speed, UTCI, or MRT for individual locations or hours.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Sen 

--- a/docs/outdoor/components/Probe_Simulation.md
+++ b/docs/outdoor/components/Probe_Simulation.md
@@ -7,7 +7,7 @@ Point Probe Inspector
  Samples the wind field at specific locations. Use this to query wind speed and pressure at points of interest like building entrances or balconies.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Run_Settings.md
+++ b/docs/outdoor/components/Run_Settings.md
@@ -7,7 +7,7 @@ Solver Control
  Configures the simulation engine, including calculation iterations, convergence criteria, and parallel processing options (CPUs).
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Iter 
@@ -31,7 +31,7 @@ Parallel processing cores. -1 = auto-detect. More cores = faster but needs more 
 * ##### OS 
 Target OS for simulation scripts. Auto-detect works in most cases.
 * ##### CFD 
-Custom BlueCFD installation path. Default: C:\Program Files\blueCFD-Core-2020
+Custom BlueCFD installation path. Default: C:\Program Files\blueCFD-Core-2024
 
 #### Output
 * ##### RSet

--- a/docs/outdoor/components/SLURM_Runner.md
+++ b/docs/outdoor/components/SLURM_Runner.md
@@ -3,7 +3,7 @@
 ![SLURM Runner Component](../images/components/SLURM_Runner-crop.png)
 
 Add batch running files for SLURM
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/STL_Exporter.md
+++ b/docs/outdoor/components/STL_Exporter.md
@@ -8,7 +8,7 @@ Export geometry to STL format for OpenFOAM or other CFD tools.
  output and single or multiple file export.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/outdoor/components/Season_Filter.md
+++ b/docs/outdoor/components/Season_Filter.md
@@ -8,7 +8,7 @@ Filter analysis results by meteorological season.
  Use to calculate seasonal comfort or radiation metrics.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Season 

--- a/docs/outdoor/components/Sensor.md
+++ b/docs/outdoor/components/Sensor.md
@@ -7,7 +7,7 @@ Single Point Sensor
  Creates a single sensor point for detailed MRT analysis at a specific location, such as a specific seat or standing spot.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Pt 

--- a/docs/outdoor/components/Settings.md
+++ b/docs/outdoor/components/Settings.md
@@ -7,7 +7,7 @@ Radiation Settings
  Configures accuracy and detail for the MRT simulation, including solar ray-tracing quality and reflections.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Refl 

--- a/docs/outdoor/components/Surface_Result_Inspector.md
+++ b/docs/outdoor/components/Surface_Result_Inspector.md
@@ -7,7 +7,7 @@ Surface Result Inspector
  Visualizes simulation results on surface polygons (e.g., building facades, ground). Displays metrics like Surface Temperature or Radiation exposure.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Polygon 

--- a/docs/outdoor/components/Surface_Settings.md
+++ b/docs/outdoor/components/Surface_Settings.md
@@ -7,7 +7,7 @@ Material Properties
  Defines thermal and optical properties for building or ground surfaces (e.g., concrete, asphalt). Controls heat calculation parameters like conductivity, density, and emissivity.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Name 

--- a/docs/outdoor/components/Templates.md
+++ b/docs/outdoor/components/Templates.md
@@ -8,7 +8,7 @@ Load example Grasshopper definitions for common workflows.
  indoor airflow simulations. Found in C:\Eddy3D\Templates.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dirs 

--- a/docs/outdoor/components/Time_of_Day_Filter.md
+++ b/docs/outdoor/components/Time_of_Day_Filter.md
@@ -8,7 +8,7 @@ Filter analysis results by time of day.
  Afternoon (4-5pm), Dinner (6-9pm), Nightlife (10pm-12am).
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Season 

--- a/docs/outdoor/components/Translate_date_to_hours.md
+++ b/docs/outdoor/components/Translate_date_to_hours.md
@@ -3,7 +3,7 @@
 ![Translate date to hours Component](../images/components/Translate_date_to_hours-crop.png)
 
 Translate Ladybug analysis period to hours of the year.
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### AP 

--- a/docs/outdoor/components/Tree.md
+++ b/docs/outdoor/components/Tree.md
@@ -7,7 +7,7 @@ Tree Modeler
  Represents trees as porous media for wind blocking. Essential for simulating the wind-sheltering effects of vegetation.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Geo 

--- a/docs/outdoor/components/Tree_Settings.md
+++ b/docs/outdoor/components/Tree_Settings.md
@@ -8,7 +8,7 @@ Define material properties for tree surfaces.
  Default uses standard deciduous tree reflectance.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### RadMat 

--- a/docs/outdoor/components/Tree_Surface.md
+++ b/docs/outdoor/components/Tree_Surface.md
@@ -7,7 +7,7 @@ Tree Canopies
  Converts tree geometries for radiation analysis. Simulates shading and evapotranspiration cooling effects.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Brep 

--- a/docs/outdoor/components/UTCI.md
+++ b/docs/outdoor/components/UTCI.md
@@ -13,7 +13,7 @@ UTCI Calculation
  - Relative Humidity
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Tair 

--- a/docs/outdoor/components/UTCI_Binning.md
+++ b/docs/outdoor/components/UTCI_Binning.md
@@ -14,7 +14,7 @@ Condition of person rating in bins. Order is as follows:
  32 to 38 = 3(strong heat stress)
  38 to 46 = 4(very strong heat stress)
  > 46 = 5(extreme heat stress)
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Cond 

--- a/docs/outdoor/components/UTCI_Rating.md
+++ b/docs/outdoor/components/UTCI_Rating.md
@@ -7,7 +7,7 @@ Comfort Categories
  Classifies UTCI values into readable categories ranging from "Extreme Cold Stress" to "Extreme Heat Stress".
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### UTCI 

--- a/docs/outdoor/components/Uniform_Flow.md
+++ b/docs/outdoor/components/Uniform_Flow.md
@@ -7,7 +7,7 @@ Uniform Wind Inlet
  Sets a constant wind speed across the entire inlet. Useful for wind tunnel calibration or simplified flow studies.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dir 

--- a/docs/outdoor/components/Vegetation_Settings.md
+++ b/docs/outdoor/components/Vegetation_Settings.md
@@ -3,7 +3,7 @@
 ![Vegetation Settings Component](../images/components/Vegetation_Settings-crop.png)
 
 Vegetation surface settings
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Name 

--- a/docs/outdoor/components/Vegetation_Surface.md
+++ b/docs/outdoor/components/Vegetation_Surface.md
@@ -8,7 +8,7 @@ Create grass/lawn surfaces for MRT simulation.
  Surface temperatures are typically lower than paved surfaces.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Brep 

--- a/docs/outdoor/components/WProbes.md
+++ b/docs/outdoor/components/WProbes.md
@@ -7,7 +7,7 @@ Wind Field Visualizer
  Generates visualizations of the wind field, including vector arrows and streamlines, to understand flow patterns and identify problematic high-wind or stagnant zones.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/WindFactorsTemporal.md
+++ b/docs/outdoor/components/WindFactorsTemporal.md
@@ -3,7 +3,7 @@
 ![WindFactorsTemporal Component](../images/components/WindFactorsTemporal-crop.png)
 
 WindFactorsTemporal
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Wind_Factors.md
+++ b/docs/outdoor/components/Wind_Factors.md
@@ -10,7 +10,7 @@ Wind Amplification Factors
  Factors are derived from wind velocity and direction for each hour, scaled by probing height. Supports either a look-up for the closest simulated wind direction or an interpolation between directions.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Wind_Factors2.md
+++ b/docs/outdoor/components/Wind_Factors2.md
@@ -8,7 +8,7 @@ Wind Factors2
  The wind factors are calculated based on the wind velocity and direction for each hour which is scaled up/down accordingly given probing height from ground.
  For this, we support either a look-up for the closest simulated wind direction or an interpolation between the closest two wind directions.
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Res 

--- a/docs/outdoor/components/Wind_Rose_Cluster.md
+++ b/docs/outdoor/components/Wind_Rose_Cluster.md
@@ -7,7 +7,7 @@ Wind Rose Clustering
  Groups wind directions into representative clusters to reduce simulation time. Essential for performing annual wind comfort analysis efficiently without simulating every single direction.
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dir 

--- a/docs/outdoor/components/Wind_Simulation.md
+++ b/docs/outdoor/components/Wind_Simulation.md
@@ -12,7 +12,7 @@ Steady-State Wind Solver (SimpleFoam)
  3. Run Simulation (simpleFoam)
 
 
- Eddy3D 0.5.0.815
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Dom 

--- a/docs/outdoor/index.md
+++ b/docs/outdoor/index.md
@@ -3,13 +3,14 @@
 ## Installation
 
 ### Plugin
-- **Windows:** [Install Eddy3D for Windows](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Install Eddy3D for Windows (opens in a new tab)" }
-- **Mac:** Install **`Eddy3D-OutdoorPlus`** via Rhino Package Manager (`yak`)
+Install **Eddy3D** via the Rhino Package Manager (`yak`) on either platform &mdash; run `PackageManager` in Rhino and search for **`Eddy3D`**.
+- **Windows:** also available as a [standalone installer](https://github.com/Eddy3D-Dev/Eddy3D/releases/latest){ target="_blank" rel="noopener noreferrer" aria-label="Install Eddy3D for Windows (opens in a new tab)" }.
+- **Mac:** install via the Package Manager as above.
 
 ### Simulation Engines (Windows / Mac)
 Choose a simulation engine (one of the following):
-- **Docker:** [Download Docker Desktop](https://www.docker.com/products/docker-desktop/){ target="_blank" rel="noopener noreferrer" aria-label="Download Docker Desktop (opens in a new tab)" } (**Recommended cross-platform**, includes pre-configured `umcf` image)
-- **BlueCFD 2020 (Windows Only):** [Download BlueCFD 2020 installer](https://github.com/blueCFD/Core/releases/download/blueCFD-Core-2020-1/blueCFD-Core-2020-1-win64-setup.exe){ target="_blank" rel="noopener noreferrer" aria-label="Download BlueCFD 2020 installer (opens in a new tab)" } (Requires `urbanMicroclimateFoam` to be installed manually)
+- **Docker:** [Download Docker Desktop](https://www.docker.com/products/docker-desktop/){ target="_blank" rel="noopener noreferrer" aria-label="Download Docker Desktop (opens in a new tab)" } (**Recommended cross-platform**, pulls a pre-configured OpenFOAM 12 image automatically)
+- **BlueCFD-Core 2024 (Windows Only):** [Download blueCFD-Core](https://bluecfd.github.io/Core/Downloads/){ target="_blank" rel="noopener noreferrer" aria-label="Download blueCFD-Core (opens in a new tab)" }
 - **WSL (Windows Only):** [WSL Installation guide for Windows](https://learn.microsoft.com/en-us/windows/wsl/install){ target="_blank" rel="noopener noreferrer" aria-label="WSL Installation guide for Windows (opens in a new tab)" } (Requires `urbanMicroclimateFoam` to be installed manually)
 
 If you would like to use the *experimental* MRT component, please [install Radiance 5.3](https://github.com/LBNL-ETA/Radiance/releases/tag/012cb178){ target="_blank" rel="noopener noreferrer" aria-label="Install Radiance 5.3 (opens in a new tab)" } in the default folder: `C:\Program Files\Radiance` (Windows) or via your package manager (Mac).

--- a/docs/outdoorplus/README.md
+++ b/docs/outdoorplus/README.md
@@ -1,4 +1,4 @@
-# UMCF Component list
+# Eddy3D — Outdoor+ Component list
 ## Air
 #### Main Components
 * [ABL Condition](components/ABL_Condition.md)

--- a/docs/outdoorplus/components/ABL_Condition.md
+++ b/docs/outdoorplus/components/ABL_Condition.md
@@ -3,7 +3,7 @@
 ![ABL Condition Component](../images/components/ABL_Condition-crop.png)
 
 Define atmospheric boundary layer settings for the air region.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### WS 

--- a/docs/outdoorplus/components/Air_Region.md
+++ b/docs/outdoorplus/components/Air_Region.md
@@ -3,7 +3,7 @@
 ![Air Region Component](../images/components/Air_Region-crop.png)
 
 Create an air region for the UMCF case.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### ABL 

--- a/docs/outdoorplus/components/Box_Domain.md
+++ b/docs/outdoorplus/components/Box_Domain.md
@@ -3,7 +3,7 @@
 ![Box Domain Component](../images/components/Box_Domain-crop.png)
 
 Define simulation domain extents and refinement padding.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### CS 

--- a/docs/outdoorplus/components/Building_Material.md
+++ b/docs/outdoorplus/components/Building_Material.md
@@ -3,7 +3,7 @@
 ![Building Material Component](../images/components/Building_Material-crop.png)
 
 Select a building material by index and override its properties.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Index 

--- a/docs/outdoorplus/components/Building_Mesh_Settings.md
+++ b/docs/outdoorplus/components/Building_Mesh_Settings.md
@@ -3,7 +3,7 @@
 ![Building Mesh Settings Component](../images/components/Building_Mesh_Settings-crop.png)
 
 Configure mesh refinement for building regions.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### FeatLvl 

--- a/docs/outdoorplus/components/Building_Region.md
+++ b/docs/outdoorplus/components/Building_Region.md
@@ -3,7 +3,7 @@
 ![Building Region Component](../images/components/Building_Region-crop.png)
 
 Create a building (solid) region for the UMCF case.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Mesh 

--- a/docs/outdoorplus/components/Case_Run.md
+++ b/docs/outdoorplus/components/Case_Run.md
@@ -3,7 +3,7 @@
 ![Case Run Component](../images/components/Case_Run-crop.png)
 
 Prepare and run a UMCF case.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/CheckMesh.md
+++ b/docs/outdoorplus/components/CheckMesh.md
@@ -3,7 +3,7 @@
 ![CheckMesh Component](../images/components/CheckMesh-crop.png)
 
 Run the OpenFOAM checkMesh command for a case region.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Run 

--- a/docs/outdoorplus/components/Create_Mesh.md
+++ b/docs/outdoorplus/components/Create_Mesh.md
@@ -3,7 +3,7 @@
 ![Create Mesh Component](../images/components/Create_Mesh-crop.png)
 
 Create a visualization mesh from polyMesh point/face data.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Create_OBJ.md
+++ b/docs/outdoorplus/components/Create_OBJ.md
@@ -3,7 +3,7 @@
 ![Create OBJ Component](../images/components/Create_OBJ-crop.png)
 
 Export an OBJ mesh from a polyMesh description.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Data 

--- a/docs/outdoorplus/components/Deconstruct_Weather.md
+++ b/docs/outdoorplus/components/Deconstruct_Weather.md
@@ -3,7 +3,7 @@
 ![Deconstruct Weather Component](../images/components/Deconstruct_Weather-crop.png)
 
 Deconstruct a Weather object into hourly time series values.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Weather 

--- a/docs/outdoorplus/components/Face_Warnings.md
+++ b/docs/outdoorplus/components/Face_Warnings.md
@@ -3,7 +3,7 @@
 ![Face Warnings Component](../images/components/Face_Warnings-crop.png)
 
 Visualize faces that fail tet decomposition during topoSet.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Get_Probes.md
+++ b/docs/outdoorplus/components/Get_Probes.md
@@ -3,7 +3,7 @@
 ![Get Probes Component](../images/components/Get_Probes-crop.png)
 
 Read probe results from a case and field.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Grass.md
+++ b/docs/outdoorplus/components/Grass.md
@@ -3,7 +3,7 @@
 ![Grass Component](../images/components/Grass-crop.png)
 
 Define grass patches and parameters for the terrain.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Boundary 

--- a/docs/outdoorplus/components/Parse_Case_Logs.md
+++ b/docs/outdoorplus/components/Parse_Case_Logs.md
@@ -3,7 +3,7 @@
 ![Parse Case Logs Component](../images/components/Parse_Case_Logs-crop.png)
 
 Parses log files in a case folder and reports any FOAM errors.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Probing.md
+++ b/docs/outdoorplus/components/Probing.md
@@ -3,7 +3,7 @@
 ![Probing Component](../images/components/Probing-crop.png)
 
 Define probe points and run probing for a UMCF case.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Read_Cells.md
+++ b/docs/outdoorplus/components/Read_Cells.md
@@ -3,7 +3,7 @@
 ![Read Cells Component](../images/components/Read_Cells-crop.png)
 
 Read cell connectivity and cell zones for a region.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Read_checkMesh.md
+++ b/docs/outdoorplus/components/Read_checkMesh.md
@@ -3,7 +3,7 @@
 ![Read checkMesh Component](../images/components/Read_checkMesh-crop.png)
 
 Read and visualize sets produced by checkMesh.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Case 

--- a/docs/outdoorplus/components/Simulation_Mesh_Settings.md
+++ b/docs/outdoorplus/components/Simulation_Mesh_Settings.md
@@ -3,7 +3,7 @@
 ![Simulation Mesh Settings Component](../images/components/Simulation_Mesh_Settings-crop.png)
 
 Configure snappyHexMesh settings for the simulation.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### AddLayers 

--- a/docs/outdoorplus/components/Simulation_Settings.md
+++ b/docs/outdoorplus/components/Simulation_Settings.md
@@ -3,7 +3,7 @@
 ![Simulation Settings Component](../images/components/Simulation_Settings-crop.png)
 
 Configure simulation control settings for UMCF.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### WriteInt 

--- a/docs/outdoorplus/components/Soil_Material.md
+++ b/docs/outdoorplus/components/Soil_Material.md
@@ -3,7 +3,7 @@
 ![Soil Material Component](../images/components/Soil_Material-crop.png)
 
 Define soil material properties for terrain layers.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Rho 

--- a/docs/outdoorplus/components/Templates.md
+++ b/docs/outdoorplus/components/Templates.md
@@ -3,7 +3,7 @@
 ![Templates Component](../images/components/Templates-crop.png)
 
 Browse built-in Grasshopper templates for OutdoorPlus.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 

--- a/docs/outdoorplus/components/Terrain_Mesh_Settings.md
+++ b/docs/outdoorplus/components/Terrain_Mesh_Settings.md
@@ -3,7 +3,7 @@
 ![Terrain Mesh Settings Component](../images/components/Terrain_Mesh_Settings-crop.png)
 
 Configure mesh settings for terrain and underground regions.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Layers 

--- a/docs/outdoorplus/components/Terrain_Region.md
+++ b/docs/outdoorplus/components/Terrain_Region.md
@@ -3,7 +3,7 @@
 ![Terrain Region Component](../images/components/Terrain_Region-crop.png)
 
 Create a terrain region with materials and depth settings.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### SurfMat 

--- a/docs/outdoorplus/components/Timing_Parameters.md
+++ b/docs/outdoorplus/components/Timing_Parameters.md
@@ -3,7 +3,7 @@
 ![Timing Parameters Component](../images/components/Timing_Parameters-crop.png)
 
 Define simulation timing and optional weather-driven time series.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Weather 

--- a/docs/outdoorplus/components/UMCF_Case.md
+++ b/docs/outdoorplus/components/UMCF_Case.md
@@ -3,7 +3,7 @@
 ![UMCF Case Component](../images/components/UMCF_Case-crop.png)
 
 Create, read, and manage an OutdoorPlus (UMCF) case.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Read 

--- a/docs/outdoorplus/components/Vegetation_Mesh_Settings.md
+++ b/docs/outdoorplus/components/Vegetation_Mesh_Settings.md
@@ -3,7 +3,7 @@
 ![Vegetation Mesh Settings Component](../images/components/Vegetation_Mesh_Settings-crop.png)
 
 Configure mesh refinement for vegetation regions.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### SurfMin 

--- a/docs/outdoorplus/components/Vegetation_Properties.md
+++ b/docs/outdoorplus/components/Vegetation_Properties.md
@@ -3,7 +3,7 @@
 ![Vegetation Properties Component](../images/components/Vegetation_Properties-crop.png)
 
 Define vegetation property coefficients for canopy modeling.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### a1 

--- a/docs/outdoorplus/components/Vegetation_Region.md
+++ b/docs/outdoorplus/components/Vegetation_Region.md
@@ -3,7 +3,7 @@
 ![Vegetation Region Component](../images/components/Vegetation_Region-crop.png)
 
 Create a vegetation region with properties and mesh settings.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Mesh 

--- a/docs/outdoorplus/components/ViewFactors.md
+++ b/docs/outdoorplus/components/ViewFactors.md
@@ -3,7 +3,7 @@
 ![ViewFactors Component](../images/components/ViewFactors-crop.png)
 
 Configure the view-factor discretization for radiation modeling.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### SideFaces 

--- a/docs/outdoorplus/components/Weather.md
+++ b/docs/outdoorplus/components/Weather.md
@@ -3,7 +3,7 @@
 ![Weather Component](../images/components/Weather-crop.png)
 
 Read an EPW file and create a Weather object for the simulation.
- OutdoorPlus 0.0.20.0
+ Eddy3D 1.0.0.827
 
 #### Input
 * ##### Path 

--- a/docs/outdoorplus/first_steps.md
+++ b/docs/outdoorplus/first_steps.md
@@ -1,9 +1,6 @@
 # Eddy3D - Outdoor+
 
-!!! warning "Alpha Version"
-    This module is currently in alpha testing. Features, inputs, and outputs are subject to change without notice.
-
-*A Grasshopper plugin for urban microclimate simulation with `urbanMicroclimateFoam` (uMFoam)*
+*The urban microclimate module of the **Eddy3D** plugin, using `urbanMicroclimateFoam` (uMFoam)*
 
 ## Overview
 
@@ -20,20 +17,22 @@
 
 ## Prerequisites
 
-### 1. Install OpenFOAM with blueCFD-Core 2020 (Windows)
+### 1. Install an OpenFOAM engine
 
-- [Download `blueCFD-Core-2020` for Windows](https://bluecfd.github.io/Core/Downloads/#bluecfd-core-2020-1){ target="_blank" rel="noopener noreferrer" aria-label="Download blueCFD-Core-2020 for Windows (opens in a new tab)" }
-- This version includes `OpenFOAM 8`.
+Eddy3D runs OpenFOAM through one of these engines (pick one):
 
-### 2. Install UMCF Plugin for Grasshopper (Rhino)
+- **Docker (Windows & macOS, recommended):** [Install Docker Desktop](https://www.docker.com/products/docker-desktop/){ target="_blank" rel="noopener noreferrer" aria-label="Install Docker Desktop (opens in a new tab)" }. Eddy3D pulls a pre-configured OpenFOAM 12 image automatically.
+- **blueCFD-Core 2024 (Windows):** [Download blueCFD-Core](https://bluecfd.github.io/Core/Downloads/){ target="_blank" rel="noopener noreferrer" aria-label="Download blueCFD-Core (opens in a new tab)" }.
+- **WSL (Windows):** [WSL installation guide](https://learn.microsoft.com/en-us/windows/wsl/install){ target="_blank" rel="noopener noreferrer" aria-label="WSL installation guide (opens in a new tab)" }.
+
+### 2. Install the Eddy3D Plugin for Grasshopper (Rhino)
 
 - Open **Rhinoceros**
 - Run the `PackageManager` command
-- Search for **UMCF**
-- Enable **"Include pre-releases"**  
+- Search for **Eddy3D**
 - Click **Install** and restart Rhino
 
-<iframe loading="lazy" title="Loom video: Install UMCF Plugin" src="https://www.loom.com/embed/aa80604bdf55468e89e213adfe3dfc03" width="640" height="360" frameborder="0" allowfullscreen></iframe>
+<iframe loading="lazy" title="Loom video: Install Eddy3D Plugin" src="https://www.loom.com/embed/aa80604bdf55468e89e213adfe3dfc03" width="640" height="360" frameborder="0" allowfullscreen></iframe>
 
 ## Verify Installation
 

--- a/docs/outdoorplus/index.md
+++ b/docs/outdoorplus/index.md
@@ -1,15 +1,12 @@
 # Eddy3D &mdash; Outdoor+
 
-!!! warning "Alpha Version"
-    This module is currently in alpha testing. Features, inputs, and outputs are subject to change without notice.
-
 ![urbanMicroclimateFoam simulation preview](./images/outdoorplus/umcf.gif){ loading=lazy }
 
-### A Grasshopper plugin for microclimate simulations
+### Fully coupled microclimate simulations in Grasshopper
 
 ___
 
-**UMCF** (`urbanMicroclimateFoam`) is an open-source solver for coupled physical processes modeling urban microclimate based on `OpenFOAM`.
+**Outdoor+** is the fully coupled microclimate module of the **Eddy3D** plugin, built on the open-source **`urbanMicroclimateFoam`** (UMCF) solver for `OpenFOAM`.
 
 ### Key Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "v0.6.2.821" # Manual fallback
+  latest_eddy_version: "1.0.0.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
Fixes the documentation inconsistencies introduced by the plugin reunification (single **Eddy3D** package, cross-platform, `1.0.0.827`). Based on a structured audit (57 findings).

**Version (94 files + config)**
- Component version stamps `Eddy3D 0.5.0.815` / `OutdoorPlus 0.0.20.0` → `Eddy3D 1.0.0.827`
- `mkdocs.yml` `latest_eddy_version` `v0.6.2.821` → `1.0.0.827`

**Package name / install (retired UMCF + Eddy3D-OutdoorPlus)**
- Install + download instructions and README titles now point to the single **Eddy3D** package via the Rhino Package Manager (search `Eddy3D`)
- Removed the "Include pre-releases" step and the "distributed under package name UMCF" note; added a "one package" note noting UMCF is retired

**Platform (now cross-platform)**
- Dropped "Windows only" / "Windows (Mac via manual install)"; all modules are Windows + Mac
- `blueCFD-Core 2020 → 2024`, `OpenFOAM 8 → 12`, Docker pulls a pre-configured OpenFOAM 12 image

**Removed** stale "Alpha Version" warnings (stable release).

**Deliberately kept:** genuine solver/component references — `urbanMicroclimateFoam`/`UMCF` *solver*, the `UMCF Case` component + its assets, `uMFoam`.

Audit method: 7 Haiku agents over the docs tree; findings verified + applied. Component version stamps are generated artifacts — bulk-replaced here; regenerating from the plugin is the longer-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)