### PR TITLE
Resize component images via CSS

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -14,6 +14,7 @@
 }
 
 .md-content img[src*="/images/components/"] {
-  width: 50%;
+  width: auto;
   height: auto;
+  zoom: 50%;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,3 +12,8 @@
   border-radius: 2px;
   flex-shrink: 0;
 }
+
+.md-content img[src*="/images/components/"] {
+  width: 50%;
+  height: auto;
+}


### PR DESCRIPTION
### Motivation
- Ensure autogenerated component documentation images render at a smaller size (50%) without modifying generated Markdown files by adding a global CSS rule.

### Description
- Added a CSS rule in `docs/stylesheets/extra.css` that targets images under `/images/components/` and sets `width: 50%` and `height: auto` to preserve aspect ratio.

### Testing
- `python -m mkdocs build` completed successfully; `python -m mkdocs build --strict` failed due to existing MkDocs warnings being treated as errors in strict mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ab70f4380832685bb1169cfbb754b)