### PR TITLE
Release 1.1.0.827: docs version bumps

### DIFF
--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -7,7 +7,7 @@ Load example Grasshopper definitions for common workflows.
  Templates include microclimate simulations, outdoor comfort studies,
  and CFD analysis setups.
  
- Version: 1.0.9.827
+ Version: 1.1.0.827
 
 #### Input
 

--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -7,7 +7,7 @@ Load example Grasshopper definitions for common workflows.
  Templates include microclimate simulations, outdoor comfort studies,
  and CFD analysis setups.
  
- Version: 1.0.8.827
+ Version: 1.0.9.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.0.9.827" # Manual fallback
+  latest_eddy_version: "1.1.0.827" # Manual fallback
 
 nav:
   - Documentation:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.0.8.827" # Manual fallback
+  latest_eddy_version: "1.0.9.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
Publish dev → main for the 1.1.0.827 release: `latest_eddy_version` + Select_Template version line (includes the deferred 1.0.9.827 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)