### PR TITLE
Release 1.2.1-beta.827: version bumps + unattended docs regeneration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+Documentation site for Eddy3D (MkDocs). Rendered docs live at https://docs.eddy3d.com/.
+
+## Branch model — read before pushing
+
+- **`dev` is the working branch**: land all changes here directly (no gated PRs between
+  feature branches and dev needed).
+- **`main` is the published branch and it is protected**: direct pushes are rejected
+  (GH013 "Changes must be made through a pull request"). Nothing you push to `dev` is
+  visible on the live site until a `dev → main` PR is merged.
+- Publishing flow: push `dev` → `gh pr create --base main --head dev` → `gh pr merge --merge`.
+
+## Release coupling
+
+On every Eddy3D plugin release (see the main repo's `.claude/skills/release-eddy3d/SKILL.md`):
+
+- `mkdocs.yml` → `latest_eddy_version` pin.
+- `docs/components/Select_Template.md` → `Version:` line.
+- Then the `dev → main` PR — the release is not done until it merges.
+
+Component pages under `docs/components/` are regenerated from the plugin
+(`tools/export_components.py` in this repo); hand-edits to generated pages get
+overwritten on the next export.

--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -7,7 +7,7 @@ Load example Grasshopper definitions for common workflows.
  Templates include microclimate simulations, outdoor comfort studies,
  and CFD analysis setups.
  
- Version: 1.1.0.827
+ Version: 1.2.1.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.1.0.827" # Manual fallback
+  latest_eddy_version: "1.2.1.827" # Manual fallback
 
 nav:
   - Documentation:

--- a/tools/generate_docs.sh
+++ b/tools/generate_docs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regenerate the component docs (markdown + icons + canvas screenshots) with no human at the canvas.
+#
+#   tools/generate_docs.sh            # regenerate, leave changes in the working tree
+#   tools/generate_docs.sh --check    # regenerate and fail if anything changed (drift detector)
+#
+# This drives the real Rhino + Grasshopper: the export captures each component off the GH canvas
+# (GH_Canvas.GenerateHiResImage), so a canvas — and therefore a logged-in GUI session — must exist.
+# It is UNATTENDED, not headless: Rhino will open, work, and quit on its own. Do not expect it to
+# run over ssh or from a cron job with no desktop; a launchd *user agent* is fine.
+#
+# Requires: Rhino 8 (licensed, with the Eddy3D plugins installed), and this repo checked out
+# alongside the Eddy3D repo (../Eddy3D/GenerateDocumentation.ghx). Override with EDDY3D_GHX.
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCS_REPO="$(cd "$TOOLS_DIR/.." && pwd)"
+RHINO_APP="${RHINO_APP:-/Applications/Rhino 8.app}"
+DRIVER="$TOOLS_DIR/run_export_unattended.py"
+
+CHECK_MODE=0
+[[ "${1:-}" == "--check" ]] && CHECK_MODE=1
+
+if [[ ! -d "$RHINO_APP" ]]; then
+  echo "Rhino not found at '$RHINO_APP'. Set RHINO_APP to your install." >&2
+  exit 2
+fi
+if [[ ! -f "$DRIVER" ]]; then
+  echo "Driver script missing: $DRIVER" >&2
+  exit 2
+fi
+
+RHINO_BIN="$RHINO_APP/Contents/MacOS/Rhinoceros"
+if [[ ! -x "$RHINO_BIN" ]]; then
+  echo "Rhino binary not found/executable: $RHINO_BIN" >&2
+  exit 2
+fi
+
+SENTINEL="$(mktemp -t eddy3d-docs)"
+trap 'rm -f "$SENTINEL"' EXIT
+export EDDY3D_DOCS_SENTINEL="$SENTINEL"
+
+if pgrep -x Rhinoceros >/dev/null; then
+  echo "A Rhino instance is already running. Quit it first — this drives its own instance." >&2
+  exit 2
+fi
+
+echo "==> Driving Rhino to regenerate docs (a Rhino window will open and close on its own)"
+# Launch the binary DIRECTLY, not via `open`: `open` starts GUI apps through launchd, which does
+# NOT inherit this shell's exported env (so EDDY3D_DOCS_SENTINEL would be lost), and its -W/-runscript
+# handling proved unreliable here. A direct exec inherits the env and lets us wait on the real PID.
+"$RHINO_BIN" -nosplash -runscript="-_RunPythonScript \"$DRIVER\"" >/dev/null 2>&1 &
+RHINO_PID=$!
+wait "$RHINO_PID" || true
+
+STATUS="$(cat "$SENTINEL" 2>/dev/null || echo "")"
+if [[ -z "$STATUS" ]]; then
+  echo "FAILED: Rhino exited without reporting a result — the export did not run to completion." >&2
+  echo "        (Run the driver with EDDY3D_DOCS_KEEP_OPEN=1 and watch the Rhino command line.)" >&2
+  exit 1
+fi
+if [[ "$STATUS" != "0" ]]; then
+  echo "FAILED: the export reported errors inside Grasshopper (see the Rhino command line)." >&2
+  exit 1
+fi
+
+echo "==> Export finished"
+cd "$DOCS_REPO"
+CHANGED="$(git status --porcelain -- docs | wc -l | tr -d ' ')"
+echo "==> $CHANGED changed file(s) under docs/"
+
+if [[ "$CHECK_MODE" == "1" ]]; then
+  if [[ "$CHANGED" != "0" ]]; then
+    echo "Docs are out of date — regenerate and commit:" >&2
+    git status --short -- docs >&2
+    exit 1
+  fi
+  echo "==> Docs are up to date"
+fi

--- a/tools/run_export_unattended.py
+++ b/tools/run_export_unattended.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Drives GenerateDocumentation.ghx without a human at the canvas.
+
+Run by Rhino itself (see generate_docs.sh), NOT by system python:
+
+    "/Applications/Rhino 8.app/Contents/MacOS/Rhinoceros" -nosplash \
+        -runscript='-_RunPythonScript "<this file>"'
+
+ENGINE GOTCHA (why this file is plain ASCII with a coding header): -_RunPythonScript may host
+this with IronPython 2, whose parser rejects any non-ASCII byte unless a PEP-263 coding line is
+present -- an em-dash in a COMMENT once produced "SyntaxError: Non-ASCII character '\\xe2'" and the
+export silently never started. Keep this file ASCII-only; keep the coding line as a belt.
+
+AS HEADLESS AS RHINO GETS: there is no headless launch mode in Rhino 8 for Mac (no -headless
+argument in the binary, no LSBackgroundOnly, and `rhinocode script` only talks to an already
+running instance). The Rhino window does open. But the Grasshopper EDITOR is never shown: the
+canvas object is created by LoadEditor() and GH_Canvas.GenerateHiResImage paints into an offscreen
+bitmap, so the screenshots do not need the editor on screen. What this removes is the HUMAN and
+the GH window; a logged-in GUI session must still exist for the canvas control to be creatable.
+
+IMPORT GOTCHA: the plain-Rhino python host references RhinoCommon but NOT Grasshopper, so a bare
+`import Grasshopper` fails ("No module named Grasshopper"). Loading the plug-in object first puts
+the assembly in the domain; clr.AddReference then makes the import resolve. (Inside a GH Python
+component neither step is needed, which is why the .ghx's own scripts do not do this.)
+
+API GOTCHA: do NOT use DocumentServer.AddDocument(doc, True) -- its second parameter is by-ref and
+the python binding rejects it ("expected StrongBox[bool], got bool"). Assigning canvas.Document is
+sufficient and registers the document.
+
+Outcome is written to the file named by EDDY3D_DOCS_SENTINEL ("0" ok, "1" failed); the wrapper
+reads it so a failed export can never look like a success. Progress is appended to
+EDDY3D_DOCS_LOG (default ~/eddy3d_docs_export.log) because Rhino's command line is invisible to
+the shell that launched it.
+"""
+
+import os
+import sys
+import traceback
+
+import clr
+import Rhino
+
+_GH = Rhino.RhinoApp.GetPlugInObject("Grasshopper")
+if _GH is None:
+    raise RuntimeError("Grasshopper plug-in object not available - is Grasshopper installed?")
+clr.AddReference("Grasshopper")
+import Grasshopper  # noqa: E402  (must follow AddReference)
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_GITHUB_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", ".."))
+GHX_PATH = os.environ.get(
+    "EDDY3D_GHX", os.path.join(_GITHUB_ROOT, "Eddy3D", "GenerateDocumentation.ghx"))
+LOG_PATH = os.environ.get(
+    "EDDY3D_DOCS_LOG", os.path.expanduser("~/eddy3d_docs_export.log"))
+
+
+def log(message):
+    line = "[docs-export] " + str(message)
+    print(line)  # Rhino command line
+    try:
+        with open(LOG_PATH, "a") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        pass
+
+
+def load_editor():
+    _GH.DisableBanner()
+    if not _GH.IsEditorLoaded():
+        log("loading Grasshopper editor (canvas object needed; the window is never shown)")
+        _GH.LoadEditor()
+    canvas = Grasshopper.Instances.ActiveCanvas
+    if canvas is None:
+        raise RuntimeError(
+            "Grasshopper editor loaded but ActiveCanvas is still null - screenshots cannot be "
+            "captured. Is this a logged-in GUI session (not ssh)?")
+    return canvas
+
+
+def open_on_canvas(path, canvas):
+    if not os.path.exists(path):
+        raise IOError("Definition not found: " + path)
+
+    io = Grasshopper.Kernel.GH_DocumentIO()
+    if not io.Open(path):
+        raise IOError("Grasshopper refused to open: " + path)
+    doc = io.Document
+    if doc is None:
+        raise IOError("Opened but produced no GH_Document: " + path)
+
+    # The export script reads Grasshopper.Instances.ActiveCanvas.Document directly
+    # (export_components.py:320) and captures off that canvas, so the definition must be the
+    # ACTIVE canvas document. See the AddDocument gotcha in the module docstring.
+    canvas.Document = doc
+    doc.Enabled = True
+    log("opened " + os.path.basename(path) + " (FilePath set: " + str(bool(doc.FilePath)) + ")")
+    return doc
+
+
+def set_export_toggles(doc, value):
+    toggled = 0
+    for obj in doc.Objects:
+        if isinstance(obj, Grasshopper.Kernel.Special.GH_BooleanToggle):
+            obj.Value = value
+            obj.ExpireSolution(False)
+            toggled += 1
+    if toggled == 0:
+        raise RuntimeError(
+            "No Boolean Toggle found - cannot trigger the export. Did the definition change?")
+    log("set " + str(toggled) + " toggle(s) to " + str(value))
+
+
+def collect_errors(doc):
+    errors = []
+    level = Grasshopper.Kernel.GH_RuntimeMessageLevel.Error
+    for obj in doc.Objects:
+        if isinstance(obj, Grasshopper.Kernel.IGH_ActiveObject):
+            for msg in obj.RuntimeMessages(level):
+                errors.append(obj.NickName + ": " + msg)
+    return errors
+
+
+def main():
+    log("definition: " + GHX_PATH)
+    canvas = load_editor()
+    doc = open_on_canvas(GHX_PATH, canvas)
+    try:
+        set_export_toggles(doc, True)
+        log("solving (writes markdown, icons and canvas captures - a few minutes)")
+        doc.NewSolution(True)  # synchronous: returns when the export has finished
+        log("solution finished")
+
+        errors = collect_errors(doc)
+        if errors:
+            raise RuntimeError("Definition reported errors:\n  " + "\n  ".join(errors))
+    finally:
+        # Leave the toggle off so an automated run does not dirty the checked-in definition.
+        try:
+            set_export_toggles(doc, False)
+        except Exception:
+            pass
+    log("export completed")
+
+
+if __name__ == "__main__":
+    exit_code = 0
+    try:
+        open(LOG_PATH, "w").close()
+        main()
+    except Exception as ex:
+        log("FAILED: " + str(ex))
+        log(traceback.format_exc())
+        exit_code = 1
+
+    sentinel = os.environ.get("EDDY3D_DOCS_SENTINEL")
+    if sentinel:
+        try:
+            with open(sentinel, "w") as fh:
+                fh.write(str(exit_code))
+        except Exception:
+            pass
+
+    # Do not let a save prompt block the unattended quit. RhinoApp.Exit() was observed NOT to
+    # terminate the process under -runscript; the _Exit command does.
+    try:
+        active = Rhino.RhinoDoc.ActiveDoc
+        if active is not None:
+            active.Modified = False
+    except Exception:
+        pass
+    if os.environ.get("EDDY3D_DOCS_KEEP_OPEN") != "1":
+        Rhino.RhinoApp.RunScript("_-Exit", False)


### PR DESCRIPTION
Brings `main` up to the current release.

- `mkdocs.yml` `latest_eddy_version` and `docs/components/Select_Template.md` `Version:` -> `1.2.1.827` (the assembly / Eddy3D-Templates branch version; the `-beta` suffix exists only in the YAK package name and git tag).
- Carries the already-merged-to-dev tooling for unattended docs regeneration.

YAK `1.2.1-beta.827` is published (win + mac) and the GitHub pre-release is live.