### PR TITLE
Release 1.4.0.827: docs version bumps

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -209,7 +209,7 @@
             <div class="index-quicklink-title">
                 <img src="/images/icons/Select_Template.png" class="nav-gh-icon"> Select Template
             </div>
-            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.2.1.827</div>
+            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827</div>
         </div>
     </a>
 </div>

--- a/docs/categories/00_Setup.md
+++ b/docs/categories/00_Setup.md
@@ -15,7 +15,7 @@
             <div class="index-quicklink-title">
                 <img src="/images/icons/Select_Template.png" class="nav-gh-icon"> Select Template
             </div>
-            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.2.1.827</div>
+            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827</div>
         </div>
     </a>
 </div>

--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -2,7 +2,7 @@
 
 ![](/images/components/Select_Template-crop.png)
 
-Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.2.1.827
+Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.2.1.827" # Manual fallback
+  latest_eddy_version: "1.4.0.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
latest_eddy_version + Select Template version -> 1.4.0.827 (also the two generated index pages carrying the stale 1.2.1.827). Companion to Eddy3D v1.4.0.827.