### PR TITLE
Release 1.5.0.827: docs version bumps

### DIFF
--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -2,7 +2,7 @@
 
 ![](/images/components/Select_Template-crop.png)
 
-Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827
+Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.5.0.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.4.0.827" # Manual fallback
+  latest_eddy_version: "1.5.0.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
Bumps `latest_eddy_version` (mkdocs.yml) and the Select Template component version line to `1.5.0.827` for the `1.5.0-beta.827` pre-release (SolarCal MRT shortwave fix, org discussion #91, Eddy3D-Dev/Eddy3D#747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145oAD42LAoo8NVyv7H2MJa

---
_Generated by [Claude Code](https://claude.ai/code/session_0145oAD42LAoo8NVyv7H2MJa)_