### PR TITLE
Release 1.6.0.827: docs version bumps

### DIFF
--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -2,7 +2,7 @@
 
 ![](/images/components/Select_Template-crop.png)
 
-Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.5.0.827
+Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.6.0.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.5.0.827" # Manual fallback
+  latest_eddy_version: "1.6.0.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
Bumps the documented plugin/template version for the `1.6.0-beta.827` pre-release.

- `mkdocs.yml` — `latest_eddy_version` → `1.6.0.827`
- `docs/components/Select_Template.md` — `Version:` → `1.6.0.827`

Both use the **assembly** version (plain 4-part, no `-beta`) — that is the string `GetBranchFromVersion` resolves to the `Eddy3D-Templates` branch, which now exists. Only the YAK package, git tag and website beta row carry `-beta`.

Docs publish from `main`, so this PR is what makes the bump live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)