### PR TITLE
release: bump documented version to 1.7.0.827

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -209,7 +209,7 @@
             <div class="index-quicklink-title">
                 <img src="/images/icons/Select_Template.png" class="nav-gh-icon"> Select Template
             </div>
-            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827</div>
+            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.7.0.827</div>
         </div>
     </a>
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -229,7 +229,7 @@
             <div class="index-quicklink-title">
                 <img src="images/icons/Select_Template.png" class="nav-gh-icon"> Select Template
             </div>
-            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.0.4.827</div>
+            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.7.0.827</div>
         </div>
     </a>
     <a href="components/Calculated_Value.md" style="text-decoration: none;">

--- a/docs/categories/00_Setup.md
+++ b/docs/categories/00_Setup.md
@@ -15,7 +15,7 @@
             <div class="index-quicklink-title">
                 <img src="/images/icons/Select_Template.png" class="nav-gh-icon"> Select Template
             </div>
-            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.4.0.827</div>
+            <div class="index-quicklink-text">Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.7.0.827</div>
         </div>
     </a>
 </div>

--- a/docs/components/Select_Template.md
+++ b/docs/components/Select_Template.md
@@ -2,7 +2,7 @@
 
 ![](/images/components/Select_Template-crop.png)
 
-Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.6.0.827
+Load example Grasshopper definitions for common workflows.  Templates include microclimate simulations, outdoor comfort studies, and CFD analysis setups.  Version: 1.7.0.827
 
 #### Input
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: >-
 extra_css:
   - stylesheets/extra.css
 extra:
-  latest_eddy_version: "1.6.0.827" # Manual fallback
+  latest_eddy_version: "1.7.0.827" # Manual fallback
 
 nav:
   - Documentation:


### PR DESCRIPTION
Version bumps for the [1.7.0.827 stable release](https://github.com/Eddy3D-Dev/Eddy3D/releases/tag/v1.7.0.827), now live on the Yak registry (win + mac).

- `mkdocs.yml` → `latest_eddy_version: 1.7.0.827`
- `docs/components/Select_Template.md` → `Version:` line

Also bumps the same Select Template blurb on three index pages that had drifted out of sync (`docs/Components.md` and `docs/categories/00_Setup.md` at 1.4.0.827, `docs/README.md` at 1.0.4.827) — the site was quoting three different versions for one component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)